### PR TITLE
ci: add release workflow with platform binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-22.04
+            asset_name: xmllint_linux-x86-64
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-22.04
+            asset_name: xmllint_linux-aarch64
+            cross: true
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            asset_name: xmllint_darwin-aarch64
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            asset_name: xmllint_windows-x86-64.exe
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --locked
+
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --features cli --target ${{ matrix.target }}
+
+      - name: Build (native)
+        if: "!matrix.cross"
+        run: cargo build --release --features cli --target ${{ matrix.target }}
+
+      - name: Rename binary (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cp target/${{ matrix.target }}/release/xmllint ${{ matrix.asset_name }}
+
+      - name: Rename binary (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Copy-Item "target/${{ matrix.target }}/release/xmllint.exe" "${{ matrix.asset_name }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: ${{ matrix.asset_name }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: xmllint_*
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered on `v*` tags
- Builds `xmllint` (the CLI binary, gated on `--features cli`) for four targets: `linux-x86-64`, `linux-aarch64`, `darwin-aarch64`, `windows-x86-64`
- Linux ARM uses [`cross`](https://github.com/cross-rs/cross) for cross-compilation; other targets build natively
- Uploads binaries as GitHub release assets named `xmllint_{os}-{arch}` (e.g. `xmllint_linux-x86-64`, `xmllint_windows-x86-64.exe`)

## Motivation

Without pre-built binaries, package managers that support the `github:` backend (e.g. [mise](https://mise.jdx.dev/)) must fall back to compiling from source via `cargo install`, which takes several minutes per machine. Binary releases make `mise install` near-instant.

The asset naming convention (`{binary}_{os}-{arch}`) matches what mise's `github:` backend auto-discovers, so no extra configuration is needed on the consumer side.

## Notes

- `fail-fast: false` keeps the matrix running if one platform fails
- Uses `Swatinem/rust-cache` (already in ci.yml) for incremental build caching
- Uses `softprops/action-gh-release` for the release step — widely used, no extra secrets needed beyond the default `GITHUB_TOKEN`