### PR TITLE
serial: emit xmlns="" undeclaration in exclusive c14n

### DIFF
--- a/src/serial/c14n.rs
+++ b/src/serial/c14n.rs
@@ -335,14 +335,20 @@ impl<'a> C14nContext<'a> {
             }
         }
 
-        if !self.options.exclusive {
-            self.check_default_ns_undeclaration(
-                &ns_decls,
-                attributes,
-                &mut ns_to_output,
-                &mut current_rendered,
-            );
-        }
+        // The default-namespace undeclaration rule applies in both modes. If
+        // the parent's default namespace is non-empty and visibly rendered in
+        // scope, and the current element is in no namespace (the source has
+        // an explicit `xmlns=""`), the canonical output must emit `xmlns=""`
+        // to undeclare it. Canonical XML 1.0 §2.3 covers the inclusive case;
+        // Exclusive C14N §3 inherits the rule (the default prefix is part of
+        // the visibly-utilized set when an explicit undeclaration is present
+        // in the source and the inherited default would otherwise propagate).
+        self.check_default_ns_undeclaration(
+            &ns_decls,
+            attributes,
+            &mut ns_to_output,
+            &mut current_rendered,
+        );
 
         // Suppress unused variable warnings for future use
         let _ = (id, name);
@@ -1100,5 +1106,63 @@ mod tests {
         // child element's unprefixed name, so it should appear.
         assert!(result.contains("xmlns=\"http://example.com\""));
         assert!(result.contains("xml:space=\"preserve\""));
+    }
+
+    /// W3C Canonical XML §2.3 — when a child element is in no namespace under
+    /// a parent that has a non-empty default namespace, the canonical output
+    /// must emit `xmlns=""` to undeclare the inherited default. This is the
+    /// inclusive-mode baseline; libxml2's `xmllint --c14n` exhibits the same.
+    #[test]
+    fn test_c14n_inclusive_emits_default_ns_undeclaration() {
+        let xml =
+            r#"<Envelope xmlns="http://example.org/usps"><NonNs xmlns="">child</NonNs></Envelope>"#;
+        let result = c14n(xml);
+        assert!(
+            result.contains("<NonNs xmlns=\"\">"),
+            "default namespace undeclaration missing, got: {result}"
+        );
+    }
+
+    /// W3C Exclusive C14N §3 inherits Canonical XML's default-namespace
+    /// undeclaration rule. Without it, the canonical form leaks the parent's
+    /// default namespace into a child that explicitly has none, producing a
+    /// digest that diverges from libxml2 / xmlsec.
+    #[test]
+    fn test_c14n_exclusive_emits_default_ns_undeclaration() {
+        let xml =
+            r#"<Envelope xmlns="http://example.org/usps"><NonNs xmlns="">child</NonNs></Envelope>"#;
+        let doc = Document::parse_str(xml).unwrap();
+        let result = canonicalize(
+            &doc,
+            &C14nOptions {
+                with_comments: false,
+                exclusive: true,
+                inclusive_prefixes: vec![],
+            },
+        );
+        assert!(
+            result.contains("<NonNs xmlns=\"\">"),
+            "exclusive C14N must emit xmlns=\"\" to undeclare inherited default ns, got: {result}"
+        );
+    }
+
+    /// Negative companion: when no inherited default exists, the output must
+    /// NOT emit a spurious `xmlns=""`.
+    #[test]
+    fn test_c14n_exclusive_no_undeclaration_when_no_inherited_default() {
+        let xml = r"<root><child>x</child></root>";
+        let doc = Document::parse_str(xml).unwrap();
+        let result = canonicalize(
+            &doc,
+            &C14nOptions {
+                with_comments: false,
+                exclusive: true,
+                inclusive_prefixes: vec![],
+            },
+        );
+        assert!(
+            !result.contains("xmlns=\"\""),
+            "exclusive C14N must not emit xmlns=\"\" when no inherited default to undeclare, got: {result}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Emit `xmlns=""` when a child element is in no namespace under a parent whose default namespace is in scope.

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (corrects an existing issue)
- [ ] New feature (adds new functionality)
- [x] Conformance fix (aligns behavior with the W3C spec or libxml2)
- [ ] Refactoring (no functional change)
- [ ] Documentation (docs, comments, examples)
- [ ] CI / tooling (build scripts, workflows, hooks)

## Spec Reference

<!-- If this change implements or fixes spec-defined behavior, cite the section.
     Delete this section if not applicable. -->

- Spec: Canonical XML 1.0
- Section: 2.3

> Namespace Axis- Consider a list L containing only namespace nodes in the axis and in the node-set in lexicographic  order (ascending). To begin processing L, if the first node is not the default namespace node (a node with no namespace URI and no local name), then generate a space followed by xmlns="" if and only if the following conditions are met:

> * the element E that owns the axis is in the node-set
> * The nearest ancestor element of E in the node-set has a default namespace node in the node-set (default namespace nodes always have non-empty values in XPath)

## Test Plan

<!-- Describe how you tested the change. Include new tests you added. -->

- [x] Added unit tests
- [ ] Added roundtrip test (parse -> serialize -> parse -> compare)
- [x] Added regression test for the bug being fixed
- [ ] Verified against W3C Conformance Test Suite
- [x] Tested manually with `xmllint`

If I have a little bit of extra time this week, I can work on wiring up a C14N conformance test. Maybe also an xmllint-libxml differential test? Let me know if that'd be helpful.

## Checklist

- [x] Code is formatted (`cargo fmt --all`)
- [x] No clippy warnings (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] All tests pass (`cargo test --all-features`)
- [x] Documentation updated for any public API changes
- [x] Commit messages follow the `<module>: <summary>` convention
- [x] No new dependencies added (or discussed and approved in an issue)
